### PR TITLE
Changes to the way setNilValueForKey is handled depending on the key

### DIFF
--- a/EasyPost/EZPAddress.m
+++ b/EasyPost/EZPAddress.m
@@ -89,4 +89,14 @@
                              }];
 }
 
+// Fix an error when trying to set the value of a BOOL to nil.
+-(void)setNilValueForKey:(NSString *)key{
+    if([key isEqualToString:@"residential"]){
+        self.residential = NO;
+    } else {
+        [super setNilValueForKey:key];
+    }
+}
+
+
 @end

--- a/EasyPost/EZPParcel.m
+++ b/EasyPost/EZPParcel.m
@@ -35,4 +35,16 @@
                              }];
 }
 
+-(void)setNilValueForKey:(NSString *)key{    
+    if ([key isEqualToString:@"height"]) {
+        [self setValue:[NSNumber numberWithFloat:0.0] forKey:@"height"];
+    } else if ([key isEqualToString:@"width"]) {
+        [self setValue:[NSNumber numberWithFloat:0.0] forKey:@"width"];
+    } else if ([key isEqualToString:@"length"]) {
+        [self setValue:[NSNumber numberWithFloat:0.0] forKey:@"length"];
+    } else {
+        [super setNilValueForKey:key];
+    }
+}
+
 @end


### PR DESCRIPTION
There were some bugs when setNilValueForKey was called on certain keys (for example in EZPParcel, if setting the height/width/length, setNilValue should actually use the float 0.0).

It's possible there are a few other cases like this (I made these changes months ago when I first started testing).
